### PR TITLE
Adding the Docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install software-properties-common wget unzip git -y && \
+    # Install Oracle JDK 8
+    add-apt-repository ppa:webupd8team/java -y && \
+    echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
+    apt-get install oracle-java8-installer -y --allow-unauthenticated && \
+    apt-get install oracle-java8-set-default && \
+    # Set UTF-8 locale
+    apt-get install -y locales && rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+    # Install Gradle
+    wget https://services.gradle.org/distributions/gradle-4.10-bin.zip && \
+    mkdir /opt/gradle && \
+    unzip -d /opt/gradle gradle-4.10-bin.zip && \
+    rm gradle-4.10-bin.zip
+
+# Export some environment variables
+ENV LANG en_US.UTF-8
+ENV GRADLE_HOME=/opt/gradle/gradle-4.10
+ENV PATH=$PATH:$GRADLE_HOME/bin
+
+WORKDIR /app
+
+CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# Quick Start
+
+- Unzip `Corda-Server.zip` in `{project-root-folder}/`
+- Open a terminal session to that folder
+- Run `docker-compose build`
+- Run `docker-compose up -d`
+- Run `docker exec -it corda-builder bash`
+- At this point you must be inside the docker container, in the root folder of the project. From there, you can run the commands as usual:
+	- `./gradlew build -x test`
+	- `./gradlew node:capsule:build webserver:webcapsule:build -x test`
+	- (...)
+- When you finish working with the container, type `exit`
+- Run `docker-compose down` to stop the service.
+
+# Dockerfile
+
+Dockefile is created on top of Ubuntu 18.04 image.
+
+Corda is actively supported on Oracle JDK 8, so in Dockerfile we setup the latest Oracle JDK 8.
+This is the minimal required software required to build and run Corda apps.
+
+Besides Oracle JDK we also install git. It will be helpful on dev environment.
+
+# docker-compose.yml
+
+The docker-compose.yml file contains a single service: `builder`.
+
+We share all Corda sources from our local environment with Docker container. There is volume with mapping shared sources to `/app` folder:
+
+```yaml
+    volumes:
+      - .:/app:Z
+```
+
+In the root of mounted volume we should have the `gradlew` script file.
+Because we can run docker-compose from Windows environment, we need to make sure that `gradlew` script is executable, so we have this command in docker-compose.yml:
+
+```yaml
+    command: bash -c "chmod +x gradlew && bash"
+```
+
+In docker-compose we expose two ranges of ports:
+
+```yaml
+    ports:
+      - "7005-7010:7005-7010"
+      - "10000-10020:10000-10020"
+```
+
+The first range 7005-7010 is used by Jolokia JVM agents. These JVM agents are started automatically when we run a Corda app.
+
+Using the range 10000-10020 we open all possible ports which are used by Corda apps in samples.
+Single Corda node may use multiple ports (for RPC messaging, P2P messaging, H2 database). And for single sample we may start 3-4 Corda nodes. So the ports range is so big.
+
+# Deploying Docker container
+
+Place Dockerfile, docker-compose.yml and .dockerignore files inside project root folder.
+
+To build the docker image execute:
+
+```
+docker-compose build
+```
+
+To run the docker container execute:
+
+```
+docker-compose up -d
+```
+
+To connect to docker container execute:
+
+```
+docker-compose exec builder bash
+```
+
+# Building
+
+To build all Corda sources including tools and samples (without tests running):
+
+```
+./gradlew build -x test
+```
+
+To build Corda core and webserver jars only (without tests running):
+
+```
+./gradlew node:capsule:build webserver:webcapsule:build -x test
+```
+
+# Running bank-of-corda sample
+
+There are instructions taken from README.md file of bank-of-corda sample app:
+
+1. Run ``./gradlew samples:bank-of-corda-demo:deployNodes`` to create a set of configs and installs under
+   ``samples/bank-of-corda-demo/build/nodes``
+2. Run ``./samples/bank-of-corda-demo/build/nodes/runnodes`` to open up three new terminal tabs/windows with the three
+   nodes
+3. Run ``./gradlew samples:bank-of-corda-demo:runRPCCashIssue`` to trigger a cash issuance request
+4. Run ``./gradlew samples:bank-of-corda-demo:runWebCashIssue`` to trigger another cash issuance request.
+   Now look at your terminal tab/window to see the output of the demo
+
+There are two Corda webserver apps running on ports 10007 and 10010, you can open it in you browser to make sure that app is running.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  builder:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    container_name: corda-builder
+    ports:
+      # open possible ports for Jolokia JVM agents
+      - "7005-7010:7005-7010"
+      # open possible ports for Corda nodes
+      - "10000-10020:10000-10020"
+    volumes:
+      - .:/app:Z
+    command: bash -c "chmod +x gradlew && bash"
+    tty: true


### PR DESCRIPTION
# Quick Start

- Unzip `Coala.zip` in `{project-root-folder}/`
- Open a terminal session to that folder
- Run `docker-compose build`
- Run `docker-compose up -d`
- Run `docker exec -it coala-builder bash`
- At this point you must be inside the docker container, in the root folder of the project. From there, you can run the commands as usual:
	- `./gradlew build -x test`
	- `./gradlew node:capsule:build webserver:webcapsule:build -x test`
	- (...)
- When you finish working with the container, type `exit`
- Run `docker-compose down` to stop the service.

# Dockerfile

Dockefile is created on top of Ubuntu 18.04 image.

Coala is actively supported on Oracle JDK 8, so in Dockerfile we setup the latest Oracle JDK 8.
This is the minimal required software required to build and run Coala apps.

Besides Oracle JDK we also install git. It will be helpful on dev environment.

# docker-compose.yml

The docker-compose.yml file contains a single service: `builder`.

We share all Coala sources from our local environment with Docker container. There is volume with mapping shared sources to `/app` folder:

```yaml
    volumes:
      - .:/app:Z
```

In the root of mounted volume we should have the `gradlew` script file.
Because we can run docker-compose from Windows environment, we need to make sure that `gradlew` script is executable, so we have this command in docker-compose.yml:

```yaml
    command: bash -c "chmod +x gradlew && bash"
```

In docker-compose we expose two ranges of ports:

```yaml
    ports:
      - "7005-7010:7005-7010"
      - "10000-10020:10000-10020"
```

The first range 7005-7010 is used by Jolokia JVM agents. These JVM agents are started automatically when we run a Coala app.

Using the range 10000-10020 we open all possible ports which are used by Coala apps in samples.
Single Coala node may use multiple ports (for RPC messaging, P2P messaging, H2 database). And for single sample we may start 3-4 Coala nodes. So the ports range is so big.

# Deploying Docker container

Place Dockerfile, docker-compose.yml and .dockerignore files inside project root folder.

To build the docker image execute:

```
docker-compose build
```

To run the docker container execute:

```
docker-compose up -d
```

To connect to docker container execute:

```
docker-compose exec builder bash
```

# Building

To build all Coala sources including tools and samples (without tests running):

```
./gradlew build -x test
```

To build Coala core and webserver jars only (without tests running):

```
./gradlew node:capsule:build webserver:webcapsule:build -x test
```

# Running bank-of-coala sample

There are instructions taken from README.md file of bank-of-coala sample app:

1. Run ``./gradlew samples:bank-of-coala-demo:deployNodes`` to create a set of configs and installs under
   ``samples/bank-of-coala-demo/build/nodes``
2. Run ``./samples/bank-of-coala-demo/build/nodes/runnodes`` to open up three new terminal tabs/windows with the three
   nodes
3. Run ``./gradlew samples:bank-of-coala-demo:runRPCCashIssue`` to trigger a cash issuance request
4. Run ``./gradlew samples:bank-of-coala-demo:runWebCashIssue`` to trigger another cash issuance request.
   Now look at your terminal tab/window to see the output of the demo

There are two Coala webserver apps running on ports 10007 and 10010, you can open it in you browser to make sure that app is running.